### PR TITLE
update naming of logo componets

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ TBD.
 ![InProduct](logo/in-product/Codatta_BlackBG_White.svg)
 
 
-| Symbol                                                   | Logotype                                                           | Wordmark                                                       |
+| Symbol                                                   | Symbol + Wordmark                                                           | Wordmark                                                       |
 | -------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------- |
 | ![SymbolWhite](logo/symbol/Codatta_Symbol_White.png)     | ![LogotypeWhite](logo/logotype/Codatta_Logotype_White.png)     | ![WordmarkWhite](logo/wordmark/Codatta_Wordmark_White.png)     |
 | ![SymbolBlack](logo/symbol/Codatta_Symbol_Black.png) | ![LogotypeBlack](logo/logotype/Codatta_Logotype_Black.png) | ![WordmarkBlack](logo/wordmark/Codatta_Wordmark_Black.png) |


### PR DESCRIPTION
* abandoned confusing names of different components (logotype vs. wordmarks, which could means same things), by referring the image below
![image](https://github.com/codatta/brand-kit/assets/859507/9b050df5-119e-4c87-96e3-ce9580cccd1b)

